### PR TITLE
:wrench: config: Add Toolkits menu and link to other UNICEF toolkits

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,10 +66,26 @@ privacy:
 
 menu:
   main:
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     - name: FAQ
       weight: 10
       url: faq
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+    - name: Data Science & A.I.
+      parent: Toolkits
+      url: https://unicef.github.io/ooi-toolkit-ds/
+      weight: 10
 
+    - name: Drones
+      parent: Toolkits
+      url: https://unicef.github.io/drone-4sdgtoolkit/
+      weight: 20
+
+    - name: Open Source
+      parent: Toolkits
+      url: https://unicef.github.io/inventory/
+      weight: 30
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
     - name: pages
       weight: 20
       url: pages


### PR DESCRIPTION
This commit adds a new drop-down menu to the Software Development site.
The _Toolkits_ drop-down includes links to @enonied4g's UNICEF Drones
for Sustainable Development Goals Toolkit. Toolkit, @jwflory's Open
Source Inventory, and @dalvarez83's Data Science & A.I. Toolkit.

![Screenshot of the upper-right portion of the screen. Pictured is the toolkits menu with links out to the other toolkits that already exist.](https://user-images.githubusercontent.com/4721034/167943906-39d5f0c8-bffa-4ebb-b592-2ceeb058bdd0.png "Screenshot of the upper-right portion of the screen. Picture is the toolkits menu with links out to the other toolkits that already exist.")