### PR TITLE
:bug: technical-capabilities: Publish "Version control" page

### DIFF
--- a/content/technical-capabilities/version-control.en.adoc
+++ b/content/technical-capabilities/version-control.en.adoc
@@ -1,7 +1,6 @@
 ---
 title: "Version Control"
 date: 2022-01-25T18:55:11+01:00
-draft: true
 weight: 10
 ---
 


### PR DESCRIPTION
This fixes the Hugo build step of the continuous integration pipeline. Currently, there is a `relref` which points to a draft site. Unless the production site is built with the development server flag, the `relref` fails. Presumably, the pipeline should pass after this commit is merged.

@iperdomo, not sure if you were ready to publish this page or not yet. Requesting your review on whether this is ready to merge.