### PR TITLE
:truck: :pencil2: Branding: Change "Innovation Fund" to "Venture Fund"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A toolkit for software development best practices, created for the UNICEF Ventur
 ## :information_source: About
 
 This repository is a collection of various software development best practices.
-It was originally created to support [UNICEF Innovation Fund](https://unicefinnovationfund.org/) teams in building software and technology projects.
+It was originally created to support [UNICEF Venture Fund](https://unicefinnovationfund.org/) teams in building software and technology projects.
 The information here can also be applied generally to projects seeking to comply with the [Digital Public Goods Standard](https://digitalpublicgoods.net/standard/).
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -118,7 +118,7 @@ params:
     parent_org_url_legal: https://www.unicef.org/legal
   footer:
     mainSite: https://www.unicefinnovationfund.org/
-    mainSiteName: UNICEF Innovation Fund
+    mainSiteName: UNICEF Venture Fund
     description: A toolkit for software development best practices, created for the UNICEF Venture Fund in the Office of Innovation.
 
 


### PR DESCRIPTION
This follows guidance shared by Mara Navarro on branding best practices
for the Venture Fund. We standardize our name as Venture Fund given the
new possibility of other funding modalities that may emerge in the
coming future.